### PR TITLE
Italicize book title in long description

### DIFF
--- a/src/epub/content.opf
+++ b/src/epub/content.opf
@@ -63,7 +63,7 @@
 		<dc:description id="description">A young girl with an overactive imagination comes of age.</dc:description>
 		<meta id="long-description" property="se:long-description" refines="#description">
 			&lt;p&gt;&lt;i&gt;Northanger Abbey&lt;/i&gt; is the coming-of-age story of Catherine Morland, a seventeen-year-old girl who’s entering society for the first time. Despite her naivete, she quickly gains two potential suitors. We follow Catherine as she tries to navigate the difficulties of romance, friendship, and responsibility—problems amplified by the fact that Catherine views her world through the lens of the dramatic Gothic novels she loves to read. &lt;a href="https://standardebooks.org/ebooks/jane-austen"&gt;Austen&lt;/a&gt; deftly satirizes both the Gothic novels popular at the time (especially &lt;a href="https://standardebooks.org/ebooks/ann-radcliffe"&gt;Ann Radcliffe’s&lt;/a&gt; &lt;a href="https://standardebooks.org/ebooks/ann-radcliffe/the-mysteries-of-udolpho"&gt;&lt;i&gt;The Mysteries of Udolpho&lt;/i&gt;&lt;/a&gt;), as well as contemporary society and women’s role in it.&lt;/p&gt;
-			&lt;p&gt;Completed in 1803, Northanger Abbey was the first of Austen’s novels to be completed, but it was only published posthumously in 1817.&lt;/p&gt;
+			&lt;p&gt;Completed in 1803, &lt;p&gt;&lt;i&gt;Northanger Abbey&lt;/i&gt; was the first of Austen’s novels to be completed, but it was only published posthumously in 1817.&lt;/p&gt;
 		</meta>
 		<dc:language>en-GB</dc:language>
 		<dc:source>https://www.gutenberg.org/ebooks/121</dc:source>


### PR DESCRIPTION
Other book titles were italicized in the long description, but the last instance of _Northanger Abbey_ wasn't.